### PR TITLE
Add server-only package to payloadClient.ts

### DIFF
--- a/payload/payloadClient.ts
+++ b/payload/payloadClient.ts
@@ -1,5 +1,6 @@
 import { getPayload } from "payload/dist/payload";
 import config from './payload.config';
+import 'server-only';
 
 if (!process.env.MONGODB_URI) {
   throw new Error('MONGODB_URI environment variable is missing')


### PR DESCRIPTION
As proposed by the next.js docs server only code should have the server-only package to prevent unwanted imports in client side code which would not work with direct API anyhow, correct?

https://nextjs.org/docs/app/building-your-application/data-fetching/caching#combining-cache-preload-and-server-only